### PR TITLE
[N/A] Remove Openfin Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "homepage": "https://github.com/HadoukenIO/service-tooling",
   "dependencies": {
-    "@types/openfin": "^39.0.1",
     "acorn": "^6.1.1",
     "archiver": "^3.0.0",
     "commander": "^2.19.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "outDir": "dist",
         "rootDir": "src",
         "lib": ["dom", "es2017"],
-        "types": ["node", "openfin"],
+        "types": ["node"],
         "jsx": "react",
         "sourceMap": false,
         "declaration": false,


### PR DESCRIPTION
Removes the `types/openfin` dependency which was causing tests builds to fail.  