### PR TITLE
[N/A] Remove default value for runtime version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-service-tooling",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -51,7 +51,8 @@
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
     },
     "@types/express": {
       "version": "4.16.1",
@@ -126,15 +127,6 @@
         "@types/node": "*"
       }
     },
-    "@types/openfin": {
-      "version": "39.0.1",
-      "resolved": "https://registry.npmjs.org/@types/openfin/-/openfin-39.0.1.tgz",
-      "integrity": "sha512-838tUlhIfeZp365xE9nH7IjCqOas+MSPtsv1twUou0XemFNGFYlz74IMlZl5Ftuw1ZBQEJAd55hgoQr0hfLygA==",
-      "requires": {
-        "@types/node": "*",
-        "@types/ws": "*"
-      }
-    },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
@@ -189,15 +181,6 @@
         "@types/loglevel": "*",
         "@types/memory-fs": "*",
         "@types/webpack": "*"
-      }
-    },
-    "@types/ws": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.1.tgz",
-      "integrity": "sha512-EzH8k1gyZ4xih/MaZTXwT2xOkPiIMSrhQ9b8wrlX88L0T02eYsddatQlwVFlEPyEqV0ChpdpNnE51QPH6NVT4Q==",
-      "requires": {
-        "@types/events": "*",
-        "@types/node": "*"
       }
     },
     "@webassemblyjs/ast": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ program.command('start')
         '-v, --providerVersion <version>',
         'Sets the runtime version for the provider.  Defaults to "local". Options: local | staging | stable | x.y.z',
         'local')
-    .option('-r, --runtime <version>', 'Sets the runtime version.  Options: stable | w.x.y.z', 'stable')
+    .option('-r, --runtime <version>', 'Sets the runtime version.  Options: stable | w.x.y.z')
     .option('-m, --mode <mode>', 'Sets the webpack mode.  Defaults to "development".  Options: development | production | none', 'development')
     .option('-n, --noDemo', 'Runs the server but will not launch the demo application.', true)
     .option('-s, --static', 'Launches the server and application using pre-built files.', true)


### PR DESCRIPTION
As is currently written, if you `npm install` and `npm start` in `layouts-service`, all applications, regardless of manifest, are launched on the `stable` runtime. This PR removes the default `stable` setting for the runtime, requiring the user to specify it in `npm start`. 