### PR TITLE
[NA] Rimraf as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-service-tooling",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -39,6 +39,7 @@
     "express": "^4.16.2",
     "file-loader": "^3.0.1",
     "node-fetch": "^2.3.0",
+    "rimraf": "^2.6.3",
     "style-loader": "^0.21.0",
     "ts-jest": "^23.10.4",
     "ts-loader": "^4.4.2",
@@ -59,7 +60,6 @@
     "glob": "^7.1.3",
     "hadouken-js-adapter": "^0.39.1",
     "pre-commit": "^1.2.2",
-    "rimraf": "^2.6.3",
     "typescript": "^3.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Makes rimraf a prod dependency so we don't need to install it in extending projects