### PR TITLE
[SERVICE-398] Runtime channels fix

### DIFF
--- a/src/scripts/createRuntimeChannels.ts
+++ b/src/scripts/createRuntimeChannels.ts
@@ -1,4 +1,4 @@
-import {writeFileSync} from 'fs';
+import {writeFileSync, existsSync} from 'fs';
 import {resolve} from 'path';
 
 import {getRootDirectory} from '../utils/getRootDirectory';
@@ -8,9 +8,9 @@ const RUNTIME_CHANNELS = ['stable', 'alpha', 'beta', 'canary'];
 /**
  * Creates copies of the provider's app.json file, that each point at a different runtime release channel.
  */
-export function createRuntimeChannels() {
+export function createRuntimeChannels(): void {
     const rootDir = getRootDirectory();
-    const manifest = require(resolve(rootDir, 'res/provider/app.json'));
+    const manifest = require(getProviderManifestPath(rootDir));
 
     RUNTIME_CHANNELS.forEach(channel => {
         manifest.runtime.version = channel;
@@ -18,4 +18,15 @@ export function createRuntimeChannels() {
         const output = JSON.stringify(manifest, null, 4);
         writeFileSync(resolve(rootDir, `dist/provider/app.runtime-${channel}.json`), output, {encoding: 'utf8'});
     });
+}
+
+function getProviderManifestPath(rootDir: string): string {
+    const distPath = resolve(rootDir, 'dist/provider/app.json');
+    const resPath = resolve(rootDir, 'res/provider/app.json');
+
+    if (existsSync(distPath)) {
+        return distPath;
+    } else {
+        return resPath;
+    }
 }

--- a/src/scripts/createRuntimeChannels.ts
+++ b/src/scripts/createRuntimeChannels.ts
@@ -9,18 +9,19 @@ const RUNTIME_CHANNELS = ['stable', 'alpha', 'beta', 'canary'];
  * Creates copies of the provider's app.json file, that each point at a different runtime release channel.
  */
 export function createRuntimeChannels(): void {
-    const rootDir = getRootDirectory();
-    const manifest = require(getProviderManifestPath(rootDir));
+    const manifest = require(getProviderManifestPath());
 
     RUNTIME_CHANNELS.forEach(channel => {
         manifest.runtime.version = channel;
 
+        const rootDir = getRootDirectory();
         const output = JSON.stringify(manifest, null, 4);
         writeFileSync(resolve(rootDir, `dist/provider/app.runtime-${channel}.json`), output, {encoding: 'utf8'});
     });
 }
 
-function getProviderManifestPath(rootDir: string): string {
+function getProviderManifestPath(): string {
+    const rootDir = getRootDirectory();
     const distPath = resolve(rootDir, 'dist/provider/app.json');
     const resPath = resolve(rootDir, 'res/provider/app.json');
 


### PR DESCRIPTION
When generating runtime channel manifests, prefer the provider manifest within the `dist` dir (if there is one) over the manifest in `res/provider`.