### PR TITLE
[N/A] Prevent test runner freezing on single core machines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-service-tooling",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/testing/runner.ts
+++ b/src/testing/runner.ts
@@ -10,8 +10,9 @@ import {CLITestArguments} from '../types';
 import getModuleRoot from '../utils/getModuleRoot';
 
 let port: number;
+let success: boolean = false;
 
-const cleanup = async (res: any) => {
+const cleanup = () => {
     if (os.platform().match(/^win/)) {
         const cmd = 'taskkill /F /IM openfin.exe /T';
         execa.shellSync(cmd);
@@ -19,12 +20,10 @@ const cleanup = async (res: any) => {
         const cmd = `lsof -n -i4TCP:${port} | grep LISTEN | awk '{ print $2 }' | xargs kill`;
         execa.shellSync(cmd);
     }
-    process.exit((res.failed===true) ? 1 : 0);
 };
 
-const fail = (err: string) => {
-    console.error(err);
-    process.exit(1);
+const exit = () => {
+    process.exit(success ? 0 : 1);
 };
 
 const run = (processName: string, args?: any[], execaOptions?: execa.Options) => {
@@ -60,11 +59,16 @@ export function runIntegrationTests(customJestArgs: string[], cliArgs: CLITestAr
             console.log('Openfin running on port ' + port);
             return port;
         })
-        .catch(fail)
+        .catch((error) => {
+            console.error(error);
+            throw new Error();
+        })
         .then(OF_PORT => run('jest', jestArgs, {env: {OF_PORT: (OF_PORT as Number).toString()}}))
+        .then(res => success = !res.failed)
         .then(cleanup)
         .catch(cleanup)
-        .catch(() => {});
+        .then(exit)
+        .catch(exit);
 }
 
 export function runUnitTests(customJestArgs: string[]) {

--- a/src/testing/runner.ts
+++ b/src/testing/runner.ts
@@ -63,7 +63,8 @@ export function runIntegrationTests(customJestArgs: string[], cliArgs: CLITestAr
         .catch(fail)
         .then(OF_PORT => run('jest', jestArgs, {env: {OF_PORT: (OF_PORT as Number).toString()}}))
         .then(cleanup)
-        .catch(cleanup);
+        .catch(cleanup)
+        .catch(() => {});
 }
 
 export function runUnitTests(customJestArgs: string[]) {


### PR DESCRIPTION
On single core machines, the test runner would lock the build process - the openfin process would be killed ahead of `runner.ts`'s `cleanup` method, and so an exception would be thrown, and `process.exit` would not be called.

Though our Jenkins VMs should now all be multi-core, maybe this can still happen in rare circumstances?

This PR ensures `process.exit` will always be called