### PR TITLE
[NA] Modify regex to allow React files (tsx) unittests

### DIFF
--- a/src/testing/jest/jest-base.config.ts
+++ b/src/testing/jest/jest-base.config.ts
@@ -18,7 +18,7 @@ export function createConfig(testType: JestMode) {
             '^.+\\.tsx?$': '<rootDir>/node_modules/ts-jest'
         },
         testRunner: 'jest-circus/runner',
-        testRegex: `\\.${testType === 'int' ? 'inttest' : 'unittest'}\\.ts$`,
+        testRegex: `\\.${testType === 'int' ? 'inttest' : 'unittest'}\\.tsx?$`,
         modulePaths: [
             '<rootDir>/node_modules'
         ],


### PR DESCRIPTION
`*.unittest.tsx` files can now be used for running tests.