### PR TITLE
[N/A] Allow alternative demo providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-service-tooling",
-  "version": "1.0.14",
+  "version": "1.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -863,9 +863,10 @@
       }
     },
     "@types/openfin": {
-      "version": "39.0.2",
-      "resolved": "https://registry.npmjs.org/@types/openfin/-/openfin-39.0.2.tgz",
-      "integrity": "sha512-DQKXLYwc0YiJRz7zvAnKwfgYzTWXrsKzwca3/ZyEgNIGCJxKbsp/7QucBPRb97pUesEXJFP4P0kw4Rt9KKZ2nw==",
+      "version": "43.0.1",
+      "resolved": "https://registry.npmjs.org/@types/openfin/-/openfin-43.0.1.tgz",
+      "integrity": "sha512-cceQvvG02BpknHdDSX6iEVs7d4cyZEjRrfeU6Z2y2rwUoHOBr2Grjag+21myfPrrqjdJCV0nJVnmkE1VKLxyzQ==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/ws": "*"
@@ -945,11 +946,11 @@
       }
     },
     "@types/ws": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.1.tgz",
-      "integrity": "sha512-EzH8k1gyZ4xih/MaZTXwT2xOkPiIMSrhQ9b8wrlX88L0T02eYsddatQlwVFlEPyEqV0ChpdpNnE51QPH6NVT4Q==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.3.tgz",
+      "integrity": "sha512-yBTM0P05Tx9iXGq00BbJPo37ox68R5vaGTXivs6RGh/BQ6QP5zqZDGWdAO6JbRE/iR1l80xeGAwCQS2nMV9S/w==",
+      "dev": true,
       "requires": {
-        "@types/events": "*",
         "@types/node": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-service-tooling",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-service-tooling",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -29,7 +29,6 @@
   "dependencies": {
     "@types/execa": "^0.9.0",
     "@types/jest": "^24.0.15",
-    "@types/openfin": "^39.0.2",
     "@types/rimraf": "^2.0.2",
     "@types/webpack": "^4.4.35",
     "@typescript-eslint/eslint-plugin": "^1.12.0",
@@ -76,6 +75,7 @@
     "@types/mkdirp": "^0.5.2",
     "@types/node": "^9.6.49",
     "@types/node-fetch": "^2.3.7",
+    "@types/openfin": "^43.0.1",
     "@types/webpack-dev-middleware": "^2.0.3",
     "fs-extra": "^7.0.1",
     "glob": "^7.1.4",

--- a/src/typedoc-template/layouts/default.hbs
+++ b/src/typedoc-template/layouts/default.hbs
@@ -35,7 +35,7 @@
             </div>
         </div>
         {{> analytics}}
-
+    <script src="{{relativeURL "assets/js/main.js"}}"></script>
     </body>
 
 </html>

--- a/src/utils/getProviderUrl.ts
+++ b/src/utils/getProviderUrl.ts
@@ -21,8 +21,13 @@ export function getProviderUrl(version: string, manifestUrl?: string) {
     const query = manifestUrl && index >= 0 ? manifestUrl.substr(index) : '';
 
     if (version === 'local') {
-        // Provider is running locally
-        return url = `http://localhost:${PORT}/provider/app.json${query}`;
+        const demoProviderResponse = existsSync(join(getRootDirectory(), 'res/demo/provider.json'));
+
+        if (demoProviderResponse) {
+            return url = `http://localhost:${PORT}/demo/provider.json${query}`;
+        } else {
+            return url = `http://localhost:${PORT}/provider/app.json${query}`;
+        }
     } else if (version === 'stable') {
         // Use the latest stable version
         return url = `${CDN_LOCATION}/app.json${query}`;
@@ -38,12 +43,12 @@ export function getProviderUrl(version: string, manifestUrl?: string) {
         } else {
             return url = `http://localhost:${PORT}/provider/app.json${query}`;
         }
-    } else if (/\d+\.\d+\.\d+/.test(version)) {
-        // Use a specific public release of the service
-        return url = `${CDN_LOCATION}/${version}/app.json${query}`;
     } else if (version.indexOf('://') > 0) {
         // Looks like an absolute URL to an app.json file
         return url = version;
+    } else if (/\d+\.\d+\.\d+/.test(version)) {
+        // Use a specific public release of the service
+        return url = `${CDN_LOCATION}/${version}/app.json${query}`;
     } else {
         throw new Error(`Not a valid version number or channel: ${version}`);
     }


### PR DESCRIPTION
Lets us use another provider manifest instead of the production manifest.  This gives us access to add different things that wont be used in production builds