### PR TITLE
[N/A] Add SIGINT support for Windows

### DIFF
--- a/demo/res/demo/app.json
+++ b/demo/res/demo/app.json
@@ -5,7 +5,7 @@
         "url": "http://localhost:42319/demo/index.html",
         "uuid": "test-launcher",
         "autoShow": true,
-        "showTaskbarIcon": false,
+        "showTaskbarIcon": true,
         "defaultHeight": 400,
         "defaultWidth": 500
     },
@@ -17,6 +17,6 @@
     ],
     "runtime": {
         "arguments": "--enable-aggressive-domstorage-flushing",
-        "version": "9.61.38.40"
+        "version": "stable"
     }
 }

--- a/demo/res/provider/app.json
+++ b/demo/res/provider/app.json
@@ -5,12 +5,12 @@
         "url": "https://cdn.openfin.co/services/openfin/test/provider.html",
         "uuid": "test-service",
         "autoShow": true,
-        "showTaskbarIcon": false,
+        "showTaskbarIcon": true,
         "defaultHeight": 400,
         "defaultWidth": 500
     },
     "runtime": {
         "arguments": "--enable-aggressive-domstorage-flushing",
-        "version": "9.61.38.40"
+        "version": "stable"
     }
 }


### PR DESCRIPTION
SIGINT (ctrl+c) isn't handled properly on windows.
This PR:
- Make SIGINT kill the server, demo apps & the service.
- Update the demo app configs to `stable` & add taskbar icons.