### PR TITLE
[N/A] Update service tooling to support SCSS files in unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-service-tooling",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4387,6 +4387,21 @@
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
+      }
+    },
+    "gonzales-pe": {
+      "version": "3.0.0-31",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-3.0.0-31.tgz",
+      "integrity": "sha1-3DDZ3GB8uEhRj6ZztOTKFYPbJVI=",
+      "requires": {
+        "minimist": "1.1.x"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag="
+        }
       }
     },
     "graceful-fs": {
@@ -8838,6 +8853,15 @@
         }
       }
     },
+    "sass-jest": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/sass-jest/-/sass-jest-0.1.7.tgz",
+      "integrity": "sha512-CyG21gxwW2RXGAi7f0Krm7RteASimIgK9t2xGzxOrxOFxL9lRjB8MkVCJ9NImVzZlRj/dFuaWGSlsyDzhzM6kw==",
+      "requires": {
+        "node-sass": "^4.9.0",
+        "sass-thematic": "^2.0.4"
+      }
+    },
     "sass-loader": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.1.0.tgz",
@@ -8849,6 +8873,14 @@
         "neo-async": "^2.5.0",
         "pify": "^3.0.0",
         "semver": "^5.5.0"
+      }
+    },
+    "sass-thematic": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sass-thematic/-/sass-thematic-2.0.4.tgz",
+      "integrity": "sha1-WPcaBzamtr7ad5AFQjjW0rpbxsY=",
+      "requires": {
+        "gonzales-pe": "3.0.0-31"
       }
     },
     "sax": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-service-tooling",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -55,6 +55,7 @@
     "node-fetch": "^2.6.0",
     "node-sass": "^4.12.0",
     "rimraf": "^2.6.3",
+    "sass-jest": "^0.1.7",
     "sass-loader": "^7.1.0",
     "style-loader": "^1.0.0",
     "ts-jest": "^24",

--- a/src/testing/jest/jest-base.config.ts
+++ b/src/testing/jest/jest-base.config.ts
@@ -15,7 +15,8 @@ export function createConfig(testType: JestMode) {
             }
         },
         transform: {
-            '^.+\\.tsx?$': '<rootDir>/node_modules/ts-jest'
+            '^.+\\.tsx?$': '<rootDir>/node_modules/ts-jest',
+            '^.+\\.scss$': '<rootDir>/node_modules/sass-jest'
         },
         testRunner: 'jest-circus/runner',
         testRegex: `\\.${testType === 'int' ? 'inttest' : 'unittest'}\\.ts$`,


### PR DESCRIPTION
Necessary for unit tests to run in Notification, giving that import chain ends up pulling in SCSS files