### PR TITLE
[N/A] Disable react/prop-types from eslint

### DIFF
--- a/src/config/.eslintrc.json
+++ b/src/config/.eslintrc.json
@@ -333,6 +333,7 @@
             "single"
         ],
         "radix": "off",
+        "react/prop-types": "off",
         "require-atomic-updates": "off",
         "require-await": "off",
         "require-jsdoc": "off",


### PR DESCRIPTION
Not required as we're using Typescript and it sometimes triggers causing an error.