### PR TITLE
[N/A] Made 'openfin-sign' dependency optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "node-fetch": "^2.6.0",
     "node-sass": "^4.13.1",
     "openfin-service-config": "^1.0.1",
-    "openfin-sign": "openfin/openfin-sign.git#v1.0.0",
     "rimraf": "^2.6.3",
     "sass-jest": "^0.1.7",
     "sass-loader": "^7.1.0",
@@ -90,6 +89,9 @@
     "openfin-service-signal": "^1.0.0",
     "pre-commit": "^1.2.2",
     "typescript": "^3.6.4"
+  },
+  "optionalDependencies": {
+    "openfin-sign": "openfin/openfin-sign.git#v1.0.0"
   },
   "peerDependencies": {
     "typescript": "3.x"

--- a/src/scripts/createAsar.ts
+++ b/src/scripts/createAsar.ts
@@ -7,12 +7,13 @@ import {getRootDirectory} from '../utils/getRootDirectory';
 const asar = require('asar');
 const fs = require('fs-extra');
 const glob = require('glob');
-const openfinSign = require('openfin-sign');
 
 /**
  * Creates a zip archive of the service provider.
  */
 export async function createAsar() {
+    const openfinSign = require('openfin-sign');
+
     const {NAME} = getProjectConfig();
     const output = path.resolve(getRootDirectory(), 'dist', 'asar');
 


### PR DESCRIPTION
Made 'openfin-sign' dependency optional, moved import to only require that module if running the asar command.