### PR TITLE
[N/A] Improved support for non-service projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-service-tooling",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-service-tooling",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -40,9 +40,6 @@ export async function createDefaultMiddleware(app: express.Express, args: CLIArg
     // Used within demo app for lauching 'custom' applications
     app.use('/manifest', createCustomManifestMiddleware());
 
-    // Add route for serving static resources
-    app.use(express.static(`${getRootDirectory()}/res`));
-
     // Add route for code
     if (args.static) {
         // Run application using pre-built code (use 'npm run build' or 'npm run build:dev')
@@ -52,6 +49,9 @@ export async function createDefaultMiddleware(app: express.Express, args: CLIArg
         // for any source file changes
         app.use(await executeWebpack(args.mode, args.writeToDisk));
     }
+
+    // Add route for serving static resources
+    app.use(express.static(`${getRootDirectory()}/res`));
 
     return app;
 }

--- a/src/webpack/webpackTools.ts
+++ b/src/webpack/webpackTools.ts
@@ -5,6 +5,7 @@ import * as ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 
 import {getProjectConfig} from '../utils/getProjectConfig';
 import {getProjectPackageJson} from '../utils/getProjectPackageJson';
+import {getRootDirectory} from '../utils/getRootDirectory';
 
 /**
  * Custom options which can be passed into webpack.
@@ -114,7 +115,8 @@ export function createConfig(outPath: string, entryPoint: string | webpack.Entry
                 checkSyntacticErrors: true,
                 async: false, // Don't build if error
                 useTypescriptIncrementalApi: true,
-                formatter: 'codeframe'
+                formatter: 'codeframe',
+                typescript: require.resolve('typescript', {paths: [getRootDirectory()]})
             })
         ]
     };
@@ -147,10 +149,10 @@ export function createConfig(outPath: string, entryPoint: string | webpack.Entry
  * Will be removed once the RVM supports relative paths within app.json files
  */
 export const manifestPlugin = (() => {
-    const {NAME, PORT} = getProjectConfig();
+    const {NAME, PORT, IS_SERVICE} = getProjectConfig();
 
     return new CopyWebpackPlugin([{
-        from: './res/provider/app.json',
+        from: IS_SERVICE ? './res/provider/app.json' : './res/app.json',
         to: '.',
         transform: (content) => {
             const config = JSON.parse(content.toString());


### PR DESCRIPTION
- Removed assumption of a client/provider/demo component in middleware
- Manifest rewriting also rewrites icon and shortcut URLs
- Middleware prioritises 'dist' dir over 'res'
- ForkTsCheckerWebpackPlugin will use TypeScript version declared in the project, rather than in tooling
- Bumped version number