### PR TITLE
[N/A] Support string templating within manifests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-service-tooling",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-service-tooling",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/utils/getManifest.ts
+++ b/src/utils/getManifest.ts
@@ -1,0 +1,95 @@
+import * as path from 'path';
+
+import {getProjectConfig} from './getProjectConfig';
+import {getJsonFileSync} from './getJsonFile';
+import {getProviderUrl} from './getProviderUrl';
+import {replaceUrlParams} from './url';
+
+/**
+ * Quick implementation on the app.json, for the pieces we use.
+ */
+export interface ManifestFile {
+    licenseKey: string;
+    startup_app: {
+        uuid: string;
+        name: string;
+        url: string;
+        autoShow?: boolean;
+        icon?: string;
+    };
+    shortcut?: {
+        icon?: string;
+    };
+    runtime: {
+        arguments?: string;
+        version: string;
+    };
+    services?: ServiceDeclaration[];
+}
+
+export interface ServiceDeclaration {
+    name: string;
+    manifestUrl?: string;
+    config?: {};
+}
+
+export enum RewriteContext {
+    /**
+     * Manifest is being re-written by the locally-running debug server.
+     *
+     * Any references to the CDN location should be replaced with localhost URLs.
+     */
+    DEBUG,
+
+    /**
+     * Manifest is being prepared for upload as part of a build.
+     *
+     * Any string templates should be evaluated, to ensure all URLs within the manifest are correct.
+     */
+    DEPLOY
+}
+
+/**
+ * Reads the given application manifest, and transforms it given the current project config and CLI args.
+ *
+ * @param configPath Path to an app.json file, must be a local file not a URL
+ * @param context Determines how CDN urls are handled, see {@link RewriteContext}
+ * @param providerVersion The requested provider version or service inclusion method
+ * @param runtimeVersion An optional runtime version override
+ */
+export function getManifest(configPath: string, context: RewriteContext, providerVersion: string, runtimeVersion?: string): ManifestFile {
+    const {PORT, NAME, CDN_LOCATION, IS_SERVICE} = getProjectConfig();
+
+    const component = IS_SERVICE ? `/${configPath.split('/')[0]}` : '';  // client, provider or demo
+    const baseUrl = context === RewriteContext.DEBUG ? `http://localhost:${PORT}${component}` : CDN_LOCATION;
+    const config: ManifestFile | void = getJsonFileSync<ManifestFile>(path.resolve('res', configPath));
+
+    if (!config || !config.startup_app) {
+        throw new Error(`${configPath} is not an app manifest`);
+    }
+
+    const serviceDefinition = (config.services || []).find((service) => service.name === NAME);
+    const {startup_app: startupApp, shortcut} = config;
+
+    // Edit manifest
+    if (startupApp.url) {
+        // Replace startup app with HTML served locally
+        startupApp.url = replaceUrlParams(startupApp.url.replace(CDN_LOCATION, baseUrl));
+    }
+    if (startupApp.icon) {
+        startupApp.icon = replaceUrlParams(startupApp.icon.replace(CDN_LOCATION, baseUrl));
+    }
+    if (shortcut && shortcut.icon) {
+        shortcut.icon = replaceUrlParams(shortcut.icon.replace(CDN_LOCATION, baseUrl));
+    }
+    if (serviceDefinition && providerVersion !== 'default') {
+        // Replace provider manifest URL with the requested version
+        serviceDefinition.manifestUrl = getProviderUrl(providerVersion, serviceDefinition.manifestUrl);
+    }
+    if (runtimeVersion) {
+        // Replace runtime version with one provided.
+        config.runtime.version = runtimeVersion;
+    }
+
+    return config;
+}

--- a/src/utils/getProjectConfig.ts
+++ b/src/utils/getProjectConfig.ts
@@ -1,4 +1,7 @@
 import {existsSync, readFileSync} from 'fs';
+import {join} from 'path';
+
+import {getRootDirectory} from './getRootDirectory';
 
 /**
  * Shape of the configuration file which is implemented in an extending project.
@@ -14,6 +17,14 @@ interface ConfigFile {
 
 export interface Config extends ConfigFile {
     IS_SERVICE: boolean;
+
+    /**
+     * The current version number of the project/service.
+     *
+     * This will be populated with the version number in `package.json`, or can be overridden using the `VERSION`
+     * environment variable.
+     */
+    VERSION: string;
 }
 
 /**
@@ -80,6 +91,9 @@ export function getProjectConfig<T extends Config = Config>(): Readonly<T> {
 
         config = {...config, ...userConfig};
     }
+
+    // Read project version
+    config.VERSION = require(join(getRootDirectory(), 'package.json')).version;
 
     // Apply CLI/env overrides
     const {env} = process;

--- a/src/utils/getProviderUrl.ts
+++ b/src/utils/getProviderUrl.ts
@@ -1,10 +1,11 @@
 import {existsSync} from 'fs';
 import {join} from 'path';
 
-import {getProjectConfig} from './getProjectConfig';
+import {getProjectConfig, Config} from './getProjectConfig';
 import {getRootDirectory} from './getRootDirectory';
+import {replaceUrlParams} from './url';
 
-let url: string|null = null;
+const urlCache: {[provider: string]: string} = {};
 
 /**
  * Returns the URL of the manifest file for the requested version of the service.
@@ -13,51 +14,52 @@ let url: string|null = null;
  * @param {string} manifestUrl The URL that was set in the application manifest (if any). Any querystring arguments will be persisted, but the rest of the URL will be ignored.
  */
 export function getProviderUrl(version: string, manifestUrl?: string) {
-    if (url) {
-        return url;
+    let url: string = urlCache[version];
+
+    if (!url) {
+        const {PORT, CDN_LOCATION} = getProjectConfig();
+        const overrideArgs: Partial<Config> = {};
+
+        if (version === 'local') {
+            const demoProviderResponse = existsSync(join(getRootDirectory(), 'res/demo/provider.json'));
+
+            if (demoProviderResponse) {
+                url = `http://localhost:${PORT}/demo/provider.json`;
+            } else {
+                url = `http://localhost:${PORT}/provider/app.json`;
+            }
+        } else if (version === 'stable') {
+            // Use the latest stable version
+            url = `${CDN_LOCATION}/app.json`;
+        } else if (version === 'staging') {
+            // Use the latest staging build
+            url = `${CDN_LOCATION}/app.staging.json`;
+        } else if (version === 'testing') {
+            // Use the optional testing provider if exists.
+            const testingProviderResponse = existsSync(join(getRootDirectory(), 'res/test/provider.json'));
+
+            if (testingProviderResponse) {
+                url = `http://localhost:${PORT}/test/provider.json`;
+            } else {
+                url = `http://localhost:${PORT}/provider/app.json`;
+            }
+        } else if (version.indexOf('://') > 0) {
+            // Looks like an absolute URL to an app.json file
+            url = version;
+        } else if (/\d+\.\d+\.\d+/.test(version)) {
+            // Use a specific public release of the service
+            url = `${CDN_LOCATION}/app.json`;
+            overrideArgs.VERSION = version;
+        } else {
+            throw new Error(`Not a valid version number or channel: ${version}`);
+        }
+
+        // Cache URL, to avoid duplicate filesystem reads/regexes/etc
+        urlCache[version] = replaceUrlParams(url);
     }
-    const {PORT, CDN_LOCATION} = getProjectConfig();
+
+    // Preserve any query args from the input manifestUrl (if specified)
     const index = (manifestUrl && manifestUrl.indexOf('?')) || -1;
-    const query = manifestUrl && index >= 0 ? manifestUrl.substr(index) : '';
-
-    if (version === 'local') {
-        const demoProviderResponse = existsSync(join(getRootDirectory(), 'res/demo/provider.json'));
-
-        if (demoProviderResponse) {
-            url = `http://localhost:${PORT}/demo/provider.json${query}`;
-            return url;
-        } else {
-            url = `http://localhost:${PORT}/provider/app.json${query}`;
-            return url;
-        }
-    } else if (version === 'stable') {
-        // Use the latest stable version
-        url = `${CDN_LOCATION}/app.json${query}`;
-        return url;
-    } else if (version === 'staging') {
-        // Use the latest staging build
-        url = `${CDN_LOCATION}/app.staging.json${query}`;
-        return url;
-    } else if (version === 'testing') {
-        // Use the optional testing provider if exists.
-        const testingProviderResponse = existsSync(join(getRootDirectory(), 'res/test/provider.json'));
-
-        if (testingProviderResponse) {
-            url = `http://localhost:${PORT}/test/provider.json${query}`;
-            return url;
-        } else {
-            url = `http://localhost:${PORT}/provider/app.json${query}`;
-            return url;
-        }
-    } else if (version.indexOf('://') > 0) {
-        // Looks like an absolute URL to an app.json file
-        url = version;
-        return url;
-    } else if (/\d+\.\d+\.\d+/.test(version)) {
-        // Use a specific public release of the service
-        url = `${CDN_LOCATION}/${version}/app.json${query}`;
-        return url;
-    } else {
-        throw new Error(`Not a valid version number or channel: ${version}`);
-    }
+    const query = index >= 0 ? manifestUrl!.substr(index) : '';
+    return `${url}${query}`;
 }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,53 @@
+import {getProjectConfig, Config} from './getProjectConfig';
+
+const trailingSlash: RegExp = /\/$/;
+const trimFragment: RegExp = /^\/*(.*?)\/*$/;
+
+const templateCache: {[template: string]: Function} = {};
+
+/**
+ * Joins all of the given strings, ensuring there is exactly one forward slash between each string, regardless of the
+ * leading/trailing slashes within each fragment.
+ *
+ * @param fragments Array of URL fragments
+ */
+export function join(...fragments: string[]): string {
+    return fragments.map((fragment) => trimFragment.exec(fragment)![1]).join('/');
+}
+
+/**
+ * Evaluates a given template, and then normalises the result by removing any trailing slash. String template uses
+ * standard JS template syntax, with "${variable}" syntax. Expressions have available the properties within the project
+ * config - see {@link Config}.
+ *
+ * For example: replaceUrlParams('${CDN_LOCATION}/${VERSION}/app.json') would be equivilant to the templated string
+ * `${getProjectConfig().CDN_LOCATION}/${getProjectConfig().VERSION}/app.json` - except that in the case of the former, the string could come from an
+ * external source (such as a manifest), whereas the latter must be specified within code.
+ *
+ * @param urlTemplate A valid URL, or string template that resolves to a valid URL
+ * @param overrideArgs Optional config overrides, to apply before evaluating template
+ */
+export function replaceUrlParams(urlTemplate: string, overrideArgs?: Partial<Config>) {
+    if (urlTemplate.indexOf('${') === -1) {
+        // Not a template, just a "plain" URL
+        return urlTemplate;
+    } else {
+        // If URL looks like a string template, insert params into string
+        const params = {...getProjectConfig(), ...overrideArgs};
+        let templateFunc: Function = templateCache[urlTemplate];
+
+        if (!templateFunc) {
+            try {
+                // eslint-disable-next-line no-new-func
+                templateFunc = new Function(...Object.keys(params), `return \`${urlTemplate}\`;`);
+            } catch (e) {
+                console.error('Error creating template function, check for syntax errors and any characters that need escaping within template string');
+                throw e;
+            }
+
+            templateCache[urlTemplate] = templateFunc;
+        }
+
+        return templateFunc(...Object.values(params)).replace(trailingSlash, '');
+    }
+}


### PR DESCRIPTION
Manifests can now contain template arguments, to account for different CDN folder structures.

Added new `VERSION` attribute to `getProjectConfig` - like `IS_SERVICE`, this is something that is set automatically (read from `package.json`) rather than explicitly set in `*.config.json`, although it can be overridden via an environment variable - to support staging builds (eg `VERSION=1.2.3-alpha.4 npm run build`).

Removed hard-coded override of app `url` and `autoShow` when building with a version number - these properties are now always set as if they were in prod when building, but overridden when running locally. This matches the behaviour of other features, such as URL re-writing and overriding runtime/provider versions.