### PR TITLE
Add CLI argument to launch demo in a Platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -590,9 +590,10 @@
       }
     },
     "@types/cli-color": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@types/cli-color/-/cli-color-0.3.29.tgz",
-      "integrity": "sha1-yDpx/gLIx+HM7ASN1qJFjR9sluo="
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@types/cli-color/-/cli-color-0.3.30.tgz",
+      "integrity": "sha512-KMMp2Km5QYLduPP6bAgydlSDiw1Tem6WDqIV48KY/D3RYsPbevccJ4W/kGDlbubeOq1XGNSqGRgLFpzC/GNNLw==",
+      "dev": true
     },
     "@types/color-name": {
       "version": "1.1.1",
@@ -723,9 +724,10 @@
       "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A=="
     },
     "@types/lodash": {
-      "version": "4.14.139",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.139.tgz",
-      "integrity": "sha512-Z6pbDYaWpluqcF8+6qgv6STPEl0jIlyQmpYGwTrzhgwqok8ltBh/p7GAmYnz81wUhxQRhEr8MBpQrB4fQ/hwIA=="
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+      "dev": true
     },
     "@types/memory-fs": {
       "version": "0.3.2",
@@ -759,7 +761,8 @@
     "@types/minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
+      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+      "dev": true
     },
     "@types/mkdirp": {
       "version": "0.5.2",
@@ -774,6 +777,7 @@
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.32.tgz",
       "integrity": "sha512-cy3yebKhrHuOcrJGkfwNHhpTXQLgmXSv1BX+4p32j+VUQ6aP2eJ5cL7OvGcAQx75fCTFaAIIAKewvqL+iwSd4g==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -781,7 +785,8 @@
     "@types/node": {
       "version": "9.6.52",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.52.tgz",
-      "integrity": "sha512-d6UdHtc8HKe3NTruj9mHk2B8EiHZyuG/00aYbUedHvy9sBhtLAX1gaxSNgvcheOvIZavvmpJYlwfHjjxlU/Few=="
+      "integrity": "sha512-d6UdHtc8HKe3NTruj9mHk2B8EiHZyuG/00aYbUedHvy9sBhtLAX1gaxSNgvcheOvIZavvmpJYlwfHjjxlU/Few==",
+      "dev": true
     },
     "@types/node-fetch": {
       "version": "2.5.2",
@@ -803,9 +808,10 @@
       }
     },
     "@types/prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-2JBasa5Qaj81Qsp/dxX2Njy+MdKC767WytHUDsRM7TYEfQvKPxsnGpnCBlBS1i2Aiv1YwCpmKSbQ6O6v8TpiKg=="
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
+      "dev": true
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -1278,7 +1284,8 @@
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+      "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
@@ -2039,7 +2046,8 @@
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
     },
     "callsites": {
       "version": "3.1.0",
@@ -2173,6 +2181,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
       "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.1.1",
         "d": "1",
@@ -2601,6 +2610,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -2924,19 +2934,21 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.51",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
-      "integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "^1.0.0"
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
       }
     },
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -2944,18 +2956,20 @@
       }
     },
     "es6-symbol": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz",
-      "integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
       "requires": {
         "d": "^1.0.1",
-        "es5-ext": "^0.10.51"
+        "ext": "^1.1.2"
       }
     },
     "es6-weak-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.46",
@@ -3333,6 +3347,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -3501,6 +3516,23 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "dev": true,
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+          "dev": true
         }
       }
     },
@@ -3866,9 +3898,10 @@
       }
     },
     "format-util": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
-      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
+      "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==",
+      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -6420,6 +6453,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema-defaults/-/json-schema-defaults-0.4.0.tgz",
       "integrity": "sha512-UsUrkDVNvHTneyeQOYHH9ZHb3+6OjwYfJ831SdO0yjtXtYZ7Jh8BKWsuJYUQW7qckP5JhHawsg4GI6A5fMaR/Q==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.9"
       }
@@ -6428,6 +6462,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
       "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
+      "dev": true,
       "requires": {
         "call-me-maybe": "^1.0.1",
         "js-yaml": "^3.12.1",
@@ -6438,6 +6473,7 @@
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-6.1.3.tgz",
       "integrity": "sha512-6nG2EPSyu3Po0FYsMEw/RpJDd6dqBr8DYIbqPZsxrRFE8g0Mxzbt6L6vlKJYrcPe9707INivn4NPJfemlXSLKw==",
+      "dev": true,
       "requires": {
         "@types/cli-color": "^0.3.29",
         "@types/json-schema": "^7.0.3",
@@ -6457,14 +6493,16 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "11.13.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.21.tgz",
-          "integrity": "sha512-fLwcSjMmDnjfk4FP7/QDiNzXSCEOGNvEe9eA6vaITmC784+Gm70wF7woaFQxUb2CpMjgLBhSPyhH0oIe1JS2uw=="
+          "version": "11.15.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.7.tgz",
+          "integrity": "sha512-3c3Kc7VIdE5UpqpmztRy7FU+turZgIurGnwpGFy/fRFOirfPc7ZnoFL83qVoqEDENJENqDhtGyQZ5fkXNQ6Qkw==",
+          "dev": true
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         }
       }
     },
@@ -6705,6 +6743,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "dev": true,
       "requires": {
         "es5-ext": "~0.10.2"
       }
@@ -6807,6 +6846,7 @@
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
       "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.45",
@@ -7115,6 +7155,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "requires": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -7162,7 +7203,8 @@
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -7551,14 +7593,16 @@
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
       "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
+      "dev": true,
       "requires": {
         "format-util": "^1.0.3"
       }
     },
     "openfin-service-config": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/openfin-service-config/-/openfin-service-config-1.0.2.tgz",
-      "integrity": "sha512-qeucC8n6u7zY2CiWt+W1TLa/ewavK3InEbl6u5vzMD7dt3Dob6coDTpNs2K+L+6Qz2PZ3SHf/ggY1N8XOrEiCw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/openfin-service-config/-/openfin-service-config-1.0.3.tgz",
+      "integrity": "sha512-f63IFjxbL8Ht03zSRgtxy0nt4SLOoE85gvCEFmLIIeVxdH4H6Cnvm5fkc3ObFhp4+cnAvItgQOobARJE8+XZgg==",
+      "dev": true,
       "requires": {
         "json-schema-defaults": "^0.4.0",
         "json-schema-to-typescript": "^6.1.3"
@@ -8008,9 +8052,10 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "dev": true
     },
     "pretty-format": {
       "version": "24.9.0",
@@ -9272,7 +9317,8 @@
     "stdin": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/stdin/-/stdin-0.0.1.tgz",
-      "integrity": "sha1-0wQZgarsPf28d6GzjWNy449ftx4="
+      "integrity": "sha1-0wQZgarsPf28d6GzjWNy449ftx4=",
+      "dev": true
     },
     "stdout-stream": {
       "version": "1.4.1",
@@ -9845,6 +9891,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "dev": true,
       "requires": {
         "any-promise": "^1.0.0"
       }
@@ -9853,6 +9900,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "dev": true,
       "requires": {
         "thenify": ">= 3.1.0 < 4"
       }
@@ -9904,6 +9952,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
       "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "dev": true,
       "requires": {
         "es5-ext": "~0.10.46",
         "next-tick": "1"
@@ -10186,7 +10235,8 @@
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4645,9 +4645,9 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
     "hadouken-js-adapter": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/hadouken-js-adapter/-/hadouken-js-adapter-0.39.1.tgz",
-      "integrity": "sha512-MecJbP/CS7Qs4SxVdYingUyzJF41aTZXPm30ynNh+WdKRKSZNcyB6jAGBHexEjiM9PdZ012P14VBIYAJAU3DMw==",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/hadouken-js-adapter/-/hadouken-js-adapter-1.44.1.tgz",
+      "integrity": "sha512-wUe/5pWzwvOHnSC26fdxT1H/pSvx47dyebms4HlUKhPXsKj8eZz+4pYlWH8gHDUDrNnAtFGPhAeVnQDRDwL+UQ==",
       "dev": true,
       "requires": {
         "@types/node": "^9.4.6",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "mini-css-extract-plugin": "^0.8.0",
     "node-fetch": "^2.6.0",
     "node-sass": "^4.13.1",
-    "openfin-service-config": "^1.0.1",
     "rimraf": "^2.6.3",
     "sass-jest": "^0.1.7",
     "sass-loader": "^7.1.0",
@@ -86,6 +85,7 @@
     "@types/webpack-dev-middleware": "^2.0.3",
     "hadouken-js-adapter": "^1.44.1",
     "mkdirp": "^0.5.1",
+    "openfin-service-config": "^1.0.3",
     "openfin-service-signal": "^1.0.0",
     "pre-commit": "^1.2.2",
     "typescript": "^3.7.5"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@types/node-fetch": "^2.3.7",
     "@types/openfin": "^43.0.1",
     "@types/webpack-dev-middleware": "^2.0.3",
-    "hadouken-js-adapter": "^0.39.1",
+    "hadouken-js-adapter": "^1.44.1",
     "mkdirp": "^0.5.1",
     "openfin-service-signal": "^1.0.0",
     "pre-commit": "^1.2.2",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ program.command('start')
         'local'
     )
     .option('-r, --runtime <version>', 'Sets the runtime version.  Options: stable | w.x.y.z')
+    .option('-p, --platform', 'Run the demo in a platform window.', false)
     .option('-m, --mode <mode>', 'Sets the webpack mode.  Defaults to "development".  Options: development | production | none', 'development')
     .option('-n, --noDemo', 'Runs the server but will not launch the demo application.', true)
     .option('-s, --static', 'Launches the server and application using pre-built files.', true)
@@ -159,6 +160,7 @@ function startTestRunner(type: JestMode, args: CLITestArguments) {
         noDemo: true,
         static: false,
         writeToDisk: true,
+        platform: false,
         filter: '',
         fileNames: '',
         runtime: '',
@@ -208,6 +210,7 @@ async function startCommandProcess(args: CLIArguments) {
         noDemo: false,
         static: false,
         writeToDisk: false,
+        platform: false,
         runtime: '',
 
         // Hooks can selectively override the above defaults. CLI args will still take precedence.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -218,7 +218,7 @@ async function startCommandProcess(args: CLIArguments) {
     }, args);
 
     const server = await createServer();
-    allowHook(Hook.APP_MIDDLEWARE)(server);
+    allowHook(Hook.APP_MIDDLEWARE)(server, parsedArgs);
     await createDefaultMiddleware(server, parsedArgs);
     await startServer(server);
     startApplication(parsedArgs);

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -15,7 +15,7 @@ import {getManifest, RewriteContext, getPlatformManifest} from '../utils/getMani
 export function createAppJsonMiddleware(providerVersion: string, runtimeVersion?: string, platform: boolean = false): RequestHandler {
     return async (req: Request, res: Response, next: NextFunction) => {
         const configPath = req.params[0];            // app.json path, relative to 'res' dir
-        const isProvider = configPath.includes('provider.json');
+        const isProvider = configPath.includes('provider');
 
         // Parse app.json
         let config: ManifestFile;

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -15,7 +15,7 @@ import {getManifest, RewriteContext, getPlatformManifest} from '../utils/getMani
 export function createAppJsonMiddleware(providerVersion: string, runtimeVersion?: string, platform: boolean = false): RequestHandler {
     return async (req: Request, res: Response, next: NextFunction) => {
         const configPath = req.params[0];            // app.json path, relative to 'res' dir
-        const isProvider = configPath.includes('provider');
+        const isProvider = configPath.toLowerCase().includes('provider');
 
         // Parse app.json
         let config: ManifestFile;

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -5,7 +5,7 @@ import {NextFunction, Request, RequestHandler, Response} from 'express-serve-sta
 import {getJsonFile} from '../utils/getJsonFile';
 import {getProjectConfig} from '../utils/getProjectConfig';
 import {getProviderUrl} from '../utils/getProviderUrl';
-import {ManifestFile, PlatformManifest, ServiceDeclaration} from '../utils/manifests';
+import {ClassicManifest, ServiceDeclaration, Manifest} from '../utils/manifests';
 import {getManifest, RewriteContext, getPlatformManifest} from '../utils/getManifest';
 
 /**
@@ -18,7 +18,7 @@ export function createAppJsonMiddleware(providerVersion: string, runtimeVersion?
         const isProvider = configPath.toLowerCase().includes('provider');
 
         // Parse app.json
-        let config: ManifestFile;
+        let config: ClassicManifest;
         try {
             config = getManifest(configPath, RewriteContext.DEBUG, providerVersion, runtimeVersion);
         } catch (e) {
@@ -31,7 +31,7 @@ export function createAppJsonMiddleware(providerVersion: string, runtimeVersion?
             config.startup_app.autoShow = true;
         }
 
-        let finalConfig: ManifestFile | PlatformManifest = config;
+        let finalConfig: Manifest = config;
         if (platform && !isProvider) {
             finalConfig = getPlatformManifest(config);
         }
@@ -52,7 +52,7 @@ export function createCustomManifestMiddleware(): RequestHandler {
     const {PORT, NAME} = getProjectConfig();
 
     return async (req, res, next) => {
-        const defaultConfig = await getJsonFile<ManifestFile>(path.resolve('./res/demo/app.json')).catch(next);
+        const defaultConfig = await getJsonFile<ClassicManifest>(path.resolve('./res/demo/app.json')).catch(next);
 
         if (!defaultConfig) {
             return;

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -11,7 +11,9 @@ import {getProviderUrl} from '../utils/getProviderUrl';
  * Creates express-compatible middleware function that will add/replace any URL's found within app.json files according
  * to the command-line options of this utility.
  */
-export function createAppJsonMiddleware(providerVersion: string, runtimeVersion?: string): RequestHandler {
+export function createAppJsonMiddleware(providerVersion: string, runtimeVersion?: string, platform: boolean = false): RequestHandler {
+    const {PORT, NAME, CDN_LOCATION} = getProjectConfig();
+
     return async (req: Request, res: Response, next: NextFunction) => {
         const configPath = req.params[0];            // app.json path, relative to 'res' dir
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -34,7 +34,7 @@ export async function createServer() {
 export async function createDefaultMiddleware(app: express.Express, args: CLIArguments) {
     // Add special route for any 'app.json' files - will re-write the contents
     // according to the command-line arguments of this server
-    app.use(/\/?(.*\.json)/, createAppJsonMiddleware(args.providerVersion, args.runtime));
+    app.use(/\/?(.*\.json)/, createAppJsonMiddleware(args.providerVersion, args.runtime, args.platform));
 
     // Add endpoint for creating new application manifests from scratch.
     // Used within demo app for lauching 'custom' applications

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,11 @@ export interface CLIArguments {
      * Sets the runtime version to be used in place of values in loaded app.json files.
      */
     runtime?: string;
+
+    /**
+     * Run the demo in a platform window.
+     */
+    platform: boolean;
 }
 
 export interface BuildCommandArgs {

--- a/src/utils/allowHook.ts
+++ b/src/utils/allowHook.ts
@@ -34,7 +34,7 @@ export enum Hook {
 
 export interface HooksAPI {
     [Hook.DEFAULT_ARGS]: () => Partial<CLIArguments>;
-    [Hook.APP_MIDDLEWARE]: (app: express.Express, args: Partial<CLIArguments>) => void;
+    [Hook.APP_MIDDLEWARE]: (app: express.Express, args: CLIArguments) => void;
     [Hook.TEST_MIDDLEWARE]: (app: express.Express) => void;
 }
 

--- a/src/utils/allowHook.ts
+++ b/src/utils/allowHook.ts
@@ -34,7 +34,7 @@ export enum Hook {
 
 export interface HooksAPI {
     [Hook.DEFAULT_ARGS]: () => Partial<CLIArguments>;
-    [Hook.APP_MIDDLEWARE]: (app: express.Express) => void;
+    [Hook.APP_MIDDLEWARE]: (app: express.Express, args: Partial<CLIArguments>) => void;
     [Hook.TEST_MIDDLEWARE]: (app: express.Express) => void;
 }
 

--- a/src/utils/getManifest.ts
+++ b/src/utils/getManifest.ts
@@ -4,7 +4,7 @@ import {getProjectConfig} from './getProjectConfig';
 import {getJsonFileSync} from './getJsonFile';
 import {getProviderUrl} from './getProviderUrl';
 import {replaceUrlParams} from './url';
-import {ManifestFile, PlatformManifest} from './manifests';
+import {ClassicManifest, PlatformManifest} from './manifests';
 
 export enum RewriteContext {
     /**
@@ -30,12 +30,12 @@ export enum RewriteContext {
  * @param providerVersion The requested provider version or service inclusion method
  * @param runtimeVersion An optional runtime version override
  */
-export function getManifest(configPath: string, context: RewriteContext, providerVersion: string, runtimeVersion?: string): ManifestFile {
+export function getManifest(configPath: string, context: RewriteContext, providerVersion: string, runtimeVersion?: string): ClassicManifest {
     const {PORT, NAME, CDN_LOCATION, IS_SERVICE} = getProjectConfig();
 
     const component = IS_SERVICE ? `/${configPath.split('/')[0]}` : '';  // client, provider or demo
     const baseUrl = context === RewriteContext.DEBUG ? `http://localhost:${PORT}${component}` : CDN_LOCATION;
-    const config: ManifestFile | void = getJsonFileSync<ManifestFile>(path.resolve('res', configPath));
+    const config: ClassicManifest | void = getJsonFileSync<ClassicManifest>(path.resolve('res', configPath));
 
     if (!config || !config.startup_app) {
         throw new Error(`${configPath} is not an app manifest`);
@@ -70,7 +70,7 @@ export function getManifest(configPath: string, context: RewriteContext, provide
 /**
  * Convert a Classic manifest into a Platform manifest.
  */
-export function getPlatformManifest(manifest: ManifestFile): PlatformManifest {
+export function getPlatformManifest(manifest: ClassicManifest): PlatformManifest {
     const {uuid, name, url, icon = ''} = manifest.startup_app;
 
     const platformConfig: PlatformManifest = {

--- a/src/utils/manifests.ts
+++ b/src/utils/manifests.ts
@@ -1,0 +1,77 @@
+import {WindowOption} from 'openfin/_v2/api/window/windowOption';
+
+/**
+ * Quick implementation on the app.json, for the pieces we use.
+ */
+export interface ManifestFile {
+    licenseKey: string;
+    startup_app: {
+        uuid: string;
+        name: string;
+        url: string;
+        defaultHeight?: number;
+        defaultWidth?: number;
+        icon?: string;
+        autoShow?: boolean;
+    };
+    shortcut?: {
+        icon?: string;
+    };
+    runtime: RuntimeInfo;
+    services?: ServiceDeclaration[];
+}
+
+export interface ServiceDeclaration {
+    name: string;
+    manifestUrl?: string;
+    config?: {};
+}
+
+interface RuntimeInfo {
+    arguments: string;
+    version: string;
+}
+
+/**
+ * There is no platform manifest type available.
+ */
+export interface PlatformManifest {
+    licenseKey: string;
+    platform: {
+        autoShow: boolean;
+        uuid: string;
+        applicationIcon: string;
+        defaultWindowOptions: Omit<WindowOption, 'autoShow' | 'uuid' | 'name'>;
+    };
+    snapshot: {
+        windows: SnapshotWindow[];
+    };
+    runtime: RuntimeInfo;
+    services?: ServiceDeclaration[];
+}
+
+interface SnapshotWindow {
+    defaultWidth: number;
+    defaultHeight: number;
+    defaultLeft?: number;
+    defaultTop?: number;
+    autoShow?: boolean;
+    layout: {
+        content: PlatformStack[];
+    };
+}
+
+interface PlatformStack {
+    type: 'stack';
+    content: (PlatformComponent | PlatformStack)[];
+}
+
+interface PlatformComponent {
+    type: 'component';
+    componentName: string;
+    componentState: {
+        name: string;
+        url: string;
+        processAffinity?: 'ps_1';
+    };
+}

--- a/src/utils/manifests.ts
+++ b/src/utils/manifests.ts
@@ -1,9 +1,11 @@
 import {WindowOption} from 'openfin/_v2/api/window/windowOption';
 
+export type Manifest = ClassicManifest | PlatformManifest;
+
 /**
  * Quick implementation on the app.json, for the pieces we use.
  */
-export interface ManifestFile {
+export interface ClassicManifest {
     licenseKey: string;
     startup_app: {
         uuid: string;


### PR DESCRIPTION
Adds an extra cli arg `-p` or `--platform` that runs the demo application in a platform window. The demo applications manifest is written into a platform config, there isn't any types available so the type definition for the config is partially defined.
The provider window isn't placed into a platform window.