### PR TITLE
[SERVICE-989] Add support for runtime-injected services

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Extracts out common build and server components which can be shared across diffe
         - -m, --mode <mode>: Sets the webpack mode.  Defaults to "development".  Options: development | production | none'
         - -n, --noDemo: Runs the server but will not launch the demo application.
         - -s, --static: Launches the server and application using pre-built files.
-        - -w, --writeToDisk: Writes and serves the built files from disk.
+        - -w, --write: Writes and serves the built files from disk.
 
 * **svc-tools build [...options]**
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Extracts out common build and server components which can be shared across diffe
     Starts the build and serves the project.
 
     - Options: 
-        - -v, --providerVersion <version>: Sets the runtime version for the provider.  Defaults to "local". Options: local | staging | stable | w.x.y.z'.
+        - -v, --providerVersion <version>: Sets the runtime version for the provider.  Defaults to "local". Options: local | staging | stable | runtime | w.x.y.z'.
         - -m, --mode <mode>: Sets the webpack mode.  Defaults to "development".  Options: development | production | none'
         - -n, --noDemo: Runs the server but will not launch the demo application.
         - -s, --static: Launches the server and application using pre-built files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -597,8 +597,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/connect": {
       "version": "3.4.32",
@@ -664,6 +663,14 @@
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "@types/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/glob": {
@@ -1223,8 +1230,7 @@
     "acorn-jsx": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
-      "dev": true
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
     },
     "acorn-walk": {
       "version": "6.2.0",
@@ -2097,8 +2103,7 @@
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "chokidar": {
       "version": "2.1.8",
@@ -2189,7 +2194,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
       }
@@ -2197,8 +2201,7 @@
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-      "dev": true
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "cliui": {
       "version": "5.0.0",
@@ -2780,7 +2783,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -3002,7 +3004,6 @@
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -3046,14 +3047,12 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -3062,7 +3061,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -3073,7 +3071,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
           "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
-          "dev": true,
           "requires": {
             "esrecurse": "^4.1.0",
             "estraverse": "^4.1.1"
@@ -3083,7 +3080,6 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
           "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-          "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -3092,7 +3088,6 @@
           "version": "12.4.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
           "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-          "dev": true,
           "requires": {
             "type-fest": "^0.8.1"
           }
@@ -3100,14 +3095,12 @@
         "ignore": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-          "dev": true
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
         },
         "optionator": {
           "version": "0.8.3",
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-          "dev": true,
           "requires": {
             "deep-is": "~0.1.3",
             "fast-levenshtein": "~2.0.6",
@@ -3120,14 +3113,12 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -3136,7 +3127,6 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -3298,7 +3288,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
       "integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
-      "dev": true,
       "requires": {
         "acorn": "^7.1.0",
         "acorn-jsx": "^5.2.0",
@@ -3308,8 +3297,7 @@
         "acorn": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-          "dev": true
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
         }
       }
     },
@@ -3322,7 +3310,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
       "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
-      "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
       }
@@ -3553,7 +3540,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
       "requires": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
@@ -3661,7 +3647,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -3670,7 +3655,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
       "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-      "dev": true,
       "requires": {
         "flat-cache": "^2.0.1"
       }
@@ -3767,7 +3751,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
       "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-      "dev": true,
       "requires": {
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
@@ -3778,7 +3761,6 @@
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -3788,8 +3770,7 @@
     "flatted": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
-      "dev": true
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
     },
     "flush-write-stream": {
       "version": "1.1.1",
@@ -4906,7 +4887,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
       "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
-      "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -5015,7 +4995,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
       "integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
-      "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^3.0.0",
@@ -5036,7 +5015,6 @@
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
           "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-          "dev": true,
           "requires": {
             "type-fest": "^0.11.0"
           }
@@ -5044,14 +5022,12 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
@@ -5061,7 +5037,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -5071,7 +5046,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -5079,32 +5053,27 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -5115,7 +5084,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -5124,7 +5092,6 @@
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -5132,8 +5099,7 @@
         "type-fest": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-          "dev": true
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
         }
       }
     },
@@ -6518,8 +6484,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -7051,8 +7016,7 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mini-css-extract-plugin": {
       "version": "0.8.0",
@@ -7153,8 +7117,7 @@
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "mz": {
       "version": "2.7.0",
@@ -7588,7 +7551,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
       "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -7617,8 +7579,9 @@
       "dev": true
     },
     "openfin-sign": {
-      "version": "github:openfin/openfin-sign#8a43b6cf28148c099a25663143263e42b5ef9b41",
-      "from": "github:openfin/openfin-sign#v1.0.0"
+      "version": "1.0.0",
+      "resolved": "github:openfin/openfin-sign#8a43b6cf28148c099a25663143263e42b5ef9b41",
+      "optional": true
     },
     "optimist": {
       "version": "0.6.1",
@@ -7777,7 +7740,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       }
@@ -8358,8 +8320,7 @@
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
-      "dev": true
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
     },
     "regexpu-core": {
       "version": "1.0.0",
@@ -8535,8 +8496,7 @@
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -8547,7 +8507,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
       "requires": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -8584,7 +8543,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
       "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
-      "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
       }
@@ -8601,7 +8559,6 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
       "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -9041,7 +8998,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
       "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
@@ -9052,7 +9008,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -9527,8 +9482,7 @@
     "strip-json-comments": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
-      "dev": true
+      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
     },
     "style-loader": {
       "version": "1.0.0",
@@ -9564,7 +9518,6 @@
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
       "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
-      "dev": true,
       "requires": {
         "ajv": "^6.10.2",
         "lodash": "^4.17.14",
@@ -9575,14 +9528,12 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -9593,7 +9544,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -9897,8 +9847,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "thenify": {
       "version": "3.3.0",
@@ -9924,8 +9873,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",
@@ -9973,7 +9921,6 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
@@ -10260,8 +10207,7 @@
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -10868,8 +10814,7 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -10944,7 +10889,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-      "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
       }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/HadoukenIO/service-tooling",
   "dependencies": {
     "@types/execa": "^0.9.0",
+    "@types/fs-extra": "^8.1.0",
     "@types/jest": "^24.0.15",
     "@types/rimraf": "^2.0.2",
     "@types/webpack": "^4.4.35",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ const defaultStartArgs: Required<CLIArguments> = {
 
 const version = require(path.resolve(getRootDirectory(), 'package.json')).version;
 
-program.version(version, '-v, --version');
+program.version(version);
 
 function toggle(value: boolean, previous: boolean) {
     return !previous;
@@ -305,25 +305,22 @@ async function prepareRuntime(args: CLIArguments): Promise<void> {
         const customRuntime = runtime.replace(runtime.split('.')[0], PORT.toString());
 
         if (!fs.existsSync(path.join(installDirectory, runtime))) {
-            console.log(`Runtime ${runtime} not installed, starting download`);
+            console.log(`Runtime ${runtime} not installed, starting download...`);
 
+            // Use the JS adapter to start an application on this runtime, then immediately exit
             const connection = await connect({
                 uuid: 'temp-app',
                 runtime: {
                     version: runtime
                 }
             });
-            console.log(await fin.System.getAllApplications());
-            await connection.Application.getCurrentSync().quit();
-
-            console.log(`Runtime ${runtime} installed`);
+            await connection['wire'].wire.shutdown();
         }
         if (!fs.existsSync(path.join(installDirectory, customRuntime))) {
-            console.log(`Runtime ${customRuntime} not prepared, starting copy`);
+            console.log(`Runtime ${customRuntime} not found, starting copy...`);
 
+            // Create a copy of this runtime. We do not want to modify the original installation, to avoid breaking other apps.
             await fs.copy(path.join(installDirectory, runtime), path.join(installDirectory, customRuntime));
-
-            console.log(`Runtime ${customRuntime} prepared`);
         }
 
         console.log(`Copying ASAR to ${customRuntime}`);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,4 +1,4 @@
-import {platform} from 'os';
+import * as os from 'os';
 
 import * as express from 'express';
 import {connect, launch} from 'hadouken-js-adapter';
@@ -62,7 +62,7 @@ export async function createDefaultMiddleware(app: express.Express, args: CLIArg
 export async function startServer(app: express.Express) {
     const {PORT} = getProjectConfig();
 
-    console.log('Starting application server...');
+    console.log(`Starting application server on port ${PORT}...`);
     return app.listen(PORT);
 }
 
@@ -73,11 +73,14 @@ export async function startApplication(args: CLIArguments) {
     const {IS_SERVICE} = getProjectConfig();
 
     // Manually start service on Mac OS (no RVM support)
-    if (IS_SERVICE && platform() === 'darwin') {
+    if (IS_SERVICE && os.platform() === 'darwin') {
         console.log('Starting Provider for Mac OS');
 
         // Launch latest stable version of the service
-        await launch({manifestUrl: getProviderUrl(args.providerVersion)}).catch(console.log);
+        const manifestUrl = getProviderUrl(args.providerVersion);
+        if (manifestUrl) {
+            await launch({manifestUrl}).catch(console.log);
+        }
     }
 
     // Launch application, if requested to do so

--- a/src/spawn/index.ts
+++ b/src/spawn/index.ts
@@ -104,7 +104,7 @@ export interface AppData<C = unknown> extends WindowData {
     useService?: boolean;
 
     /**
-     * The version of the provider to use. Either local/staging/stable, or a version number from the CDN.
+     * The version of the provider to use. Either local/staging/stable/runtime, or a version number from the CDN.
      *
      * Has no effect if `useService` is false.
      */

--- a/src/spawn/index.ts
+++ b/src/spawn/index.ts
@@ -104,7 +104,15 @@ export interface AppData<C = unknown> extends WindowData {
     useService?: boolean;
 
     /**
-     * The version of the provider to use. Either local/staging/stable/runtime, or a version number from the CDN.
+     * Switches the method by which the service is started from the 'desktop service' model to the 'runtime injection'
+     * model. This is only available on services that are configured to use the asar method (see
+     * `ConfigFile.RUNTIME_INJECTABLE`).
+     */
+    asar?: boolean;
+
+    /**
+     * The version of the provider to use. Either local/staging/stable/testing, an absolute manifest URL, or a version
+     * number from a build that has been deployed to the CDN.
      *
      * Has no effect if `useService` is false.
      */
@@ -215,6 +223,7 @@ async function createApplication(options: Omit<AppData, 'parent'>): Promise<Appl
             enableMesh: options.enableMesh || false,
             runtime: options.runtime || await fin.System.getVersion(),
             useService: options.useService !== undefined ? options.useService : true,
+            asar: options.asar !== undefined ? options.asar : false,
             provider: options.provider || 'local',
             config: options.config ? JSON.stringify(options.config) : ''
         };

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export interface CLIArguments {
      *   Runs the latest public release of the service from the OpenFin CDN
      * - "staging"
      *   Runs the latest internal build of the service from the OpenFin CDN. May be unstable.
+     * - "runtime"
+     *   Will start the service through an ASAR baked into the runtime. Available only if ASAR_FLAG is defined within the service config.
      * - <version number>
      *   Specifiying a "x.y.z" version number will load that version of the service from the OpenFin CDN.
      */

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,12 +9,19 @@ export interface CLIArguments {
      *   Runs the latest public release of the service from the OpenFin CDN
      * - "staging"
      *   Runs the latest internal build of the service from the OpenFin CDN. May be unstable.
-     * - "runtime"
-     *   Will start the service through an ASAR baked into the runtime. Available only if ASAR_FLAG is defined within the service config.
      * - <version number>
      *   Specifiying a "x.y.z" version number will load that version of the service from the OpenFin CDN.
      */
     providerVersion: string;
+
+    /**
+     * Starts the provider from an ASAR, rather than as a desktop service.
+     *
+     * Can only be used if RUNTIME_INJECTABLE is defined in project config. Note that this makes debugging of the
+     * provider more difficult, as it will run from an ASAR injected into a custom runtime rather than as a "standard"
+     * web app.
+     */
+    asar: boolean;
 
     /**
      * The mode to use for webpack, either 'development' (default) or 'production'.
@@ -26,7 +33,7 @@ export interface CLIArguments {
      *
      * Otherwise will build and start the local server, but not automatically launch any applications.
      */
-    noDemo: boolean;
+    demo: boolean;
 
     /**
      * Rather than building the application via webpack (and then watching for any source file changes), will launch the
@@ -41,7 +48,7 @@ export interface CLIArguments {
      * By default, webpack-dev-server builds and serves files from memory without writing to disk.
      * Using this option will also write the output to the 'dist' folder, as if running one of the 'build' scripts.
      */
-    writeToDisk: boolean;
+    write: boolean;
 
     /**
      * Sets the runtime version to be used in place of values in loaded app.json files.

--- a/src/utils/allowHook.ts
+++ b/src/utils/allowHook.ts
@@ -47,7 +47,7 @@ export function loadHooks(): void {
         if (!fs.existsSync(hooksPathOut) || fs.statSync(hooksPathSrc).mtime > fs.statSync(hooksPathOut).mtime) {
             console.log('Building hooks...');
             try {
-                execa.sync('tsc', [hooksPathSrc, '--outDir', path.dirname(hooksPathOut), '--moduleResolution', 'node'], {stdio: 'pipe'});
+                execa.sync('./node_modules/.bin/tsc', [hooksPathSrc, '--outDir', path.dirname(hooksPathOut), '--moduleResolution', 'node'], {stdio: 'pipe'});
             } catch (e) {
                 console.error(`Error building hooks:\n${e.stdout}`);
 

--- a/src/utils/allowHook.ts
+++ b/src/utils/allowHook.ts
@@ -27,14 +27,15 @@ export enum Hook {
     /**
      * Hook to override default values for the `npm start` CLI options.
      *
-     * Note that using this hook may make some of the text in `npm start --help` inaccurate.
+     * When using this hook, the help text in `npm start --help` will update accordingly, to show the new default
+     * values for each option.
      */
     DEFAULT_ARGS = 'DEFAULT_ARGS'
 }
 
 export interface HooksAPI {
-    [Hook.DEFAULT_ARGS]: () => Partial<CLIArguments>;
     [Hook.APP_MIDDLEWARE]: (app: express.Express) => void;
+    [Hook.DEFAULT_ARGS]: () => Partial<CLIArguments>;
     [Hook.TEST_MIDDLEWARE]: (app: express.Express) => void;
 }
 

--- a/src/utils/allowHook.ts
+++ b/src/utils/allowHook.ts
@@ -18,12 +18,14 @@ export enum Hook {
      * Any middleware added via this hook will take precedence over the "built-in" middleware.
      */
     APP_MIDDLEWARE = 'APP_MIDDLEWARE',
+
     /**
      * Register middleware with the local server that runs during integration tests.
      *
      * Any middleware added via this hook will take precedence over the "built-in" middleware.
      */
     TEST_MIDDLEWARE = 'TEST_MIDDLEWARE',
+
     /**
      * Hook to override default values for the `npm start` CLI options.
      *
@@ -34,9 +36,9 @@ export enum Hook {
 }
 
 export interface HooksAPI {
-    [Hook.APP_MIDDLEWARE]: (app: express.Express) => void;
+    [Hook.APP_MIDDLEWARE]: (app: express.Express) => void | Promise<void>;
     [Hook.DEFAULT_ARGS]: () => Partial<CLIArguments>;
-    [Hook.TEST_MIDDLEWARE]: (app: express.Express) => void;
+    [Hook.TEST_MIDDLEWARE]: (app: express.Express) => void | Promise<void>;
 }
 
 export function loadHooks(): void {
@@ -47,7 +49,15 @@ export function loadHooks(): void {
         if (!fs.existsSync(hooksPathOut) || fs.statSync(hooksPathSrc).mtime > fs.statSync(hooksPathOut).mtime) {
             console.log('Building hooks...');
             try {
-                execa.sync('./node_modules/.bin/tsc', [hooksPathSrc, '--outDir', path.dirname(hooksPathOut), '--moduleResolution', 'node'], {stdio: 'pipe'});
+                execa.sync('./node_modules/.bin/tsc', [
+                    hooksPathSrc,
+                    '--outDir',
+                    path.dirname(hooksPathOut),
+                    '--moduleResolution',
+                    'node',
+                    '--target',
+                    'es5'
+                ], {stdio: 'pipe'});
             } catch (e) {
                 console.error(`Error building hooks:\n${e.stdout}`);
 

--- a/src/utils/getProjectConfig.ts
+++ b/src/utils/getProjectConfig.ts
@@ -32,12 +32,16 @@ interface ConfigFile {
     CDN_LOCATION: string;
 
     /**
-     * If using this service through runtime injection, this option defines the property that must be added to the
-     * applications manifest in order to enable the runtime injection of the client library.
+     * Indicates if this service supports runtime injection - meaning that this is a service that can be started via
+     * ASAR by the runtime. This replaces the RVM-managed service model (though that method is still supported).
      *
-     * This option is required in order to use 'runtime' as the --providerVersion argument.
+     * This option is required in order to use the --asar option on the 'npm start' and 'npm run test' commands. Do not
+     * use this parameter to control the startup method on a case-by-case basis, use the --asar argument for that
+     * (which is supported by both 'start' and 'test int').
+     *
+     * When enabled, three additional parameters are supported within the 'startup_app' section of a manifest. Each is prefixed
      */
-    ASAR_FLAG?: string;
+    RUNTIME_INJECTABLE?: boolean;
 
     /**
      * The manifest to use when starting the application. Allows overriding of the demo app manifest location.

--- a/src/utils/getProjectConfig.ts
+++ b/src/utils/getProjectConfig.ts
@@ -4,15 +4,57 @@ import {existsSync, readFileSync} from 'fs';
  * Shape of the configuration file which is implemented in an extending project.
  */
 interface ConfigFile {
+    /**
+     * The "clean" name of this project, all lower-case and with no special characters.
+     *
+     * This is used as the name of the exported NPM module, JS script, CDN upload directory, and so on.
+     */
     NAME: string;
+
+    /**
+     * Human-readable equivilant of `NAME`, allows the use of mixed-case and filesystem-reserved characters.
+     */
     TITLE: string;
+
+    /**
+     * The port that the local development server will run on, when running `npm start`
+     */
     PORT: number;
+
+    /**
+     * The location on the CDN where this project is uploaded to when deployed. Within manifests and any other files
+     * that require absolute URLs, these should always reference the deployed location of the target. When debugging
+     * locally, there will be a middleware on the local server that maps these URLs to their locally-hosted
+     * equivalents. The value of this property controls which URLs get re-mapped.
+     *
+     * This should be the externally-facing URL, rather than the internal AWS bucket URL.
+     */
     CDN_LOCATION: string;
 
+    /**
+     * If using this service through runtime injection, this option defines the property that must be added to the
+     * applications manifest in order to enable the runtime injection of the client library.
+     *
+     * This option is required in order to use 'runtime' as the --providerVersion argument.
+     */
+    ASAR_FLAG?: string;
+
+    /**
+     * The manifest to use when starting the application. Allows overriding of the demo app manifest location.
+     *
+     * This is the manifest that is launched when running `npm start`.
+     */
     MANIFEST?: string;
 }
 
 export interface Config extends ConfigFile {
+    /**
+     * Indicates if the current project is a Desktop Service (true), or a standalone Application (false). Services have
+     * a more complex folder structure, due to their multiple components.
+     *
+     * This is not specified explicitly in a config file, rather it is inferred from the name of the config file used
+     * by the project. See the README for more information.
+     */
     IS_SERVICE: boolean;
 }
 

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -1,0 +1,185 @@
+import * as path from 'path';
+import * as os from 'os';
+
+import {shell} from 'execa';
+import * as fs from 'fs-extra';
+import {connect} from 'hadouken-js-adapter';
+
+import {CLIArguments} from '../types';
+
+import {getProjectConfig} from './getProjectConfig';
+import {getProviderPath} from './manifest';
+import {getRootDirectory} from './getRootDirectory';
+
+const RELEASE_CHANNELS = ['stable', 'alpha', 'beta', 'canary', 'canary-next'];
+
+/**
+ * If using a runtime-injected service prepare an ASAR that contains the service, and create a custom version of the
+ * runtime that contains that version of the service.
+ *
+ * @param args CLI arguments for start/test command
+ */
+export async function prepareRuntime(args: CLIArguments): Promise<void> {
+    if (args.asar) {
+        const {NAME} = getProjectConfig();
+
+        if (args.static || args.write) {
+            // Will still build ASAR even when using --static, as it's a quick operation.
+            console.log('Building ASAR (from existing build)...');
+            await shell('npm run asar', {cwd: getRootDirectory()});
+        } else {
+            console.log(`Building ASAR (${args.mode} mode)...`);
+            await shell(`npm run build -m ${args.mode}`, {cwd: getRootDirectory()});
+            await shell('npm run asar', {cwd: getRootDirectory()});
+        }
+
+        const runtime: string = args.runtime || require(getProviderPath()).runtime.version;
+        const isChannel = isReleaseChannel(runtime);
+        let runtimeVersion = runtime;
+
+        if (isChannel || !isRuntimeInstalled(runtime)) {
+            console.log(isChannel ? `Converting channel ${runtime} to build number` : `Runtime ${runtime} not installed, starting download...`);
+            const timeout = isChannel
+                ? setTimeout(() => {
+                    console.log('Resolution is taking a while, runtime probably isn\'t installed...');
+                }, 1500)
+                : undefined;
+
+            runtimeVersion = await installRuntime(runtime);
+            clearTimeout(timeout!);
+
+            if (isChannel) {
+                console.log(`Resolved ${runtime} to ${runtimeVersion}`);
+            }
+        }
+
+        const customRuntime = mapRuntimeVersion(runtimeVersion);
+        if (!isRuntimeInstalled(customRuntime)) {
+            console.log(`Runtime ${customRuntime} not found, starting copy...`);
+
+            // Create a copy of this runtime. We do not want to modify the original installation, to avoid breaking other apps.
+            await fs.copy(getInstallDirectory(runtimeVersion), getInstallDirectory(customRuntime));
+        }
+
+        console.log(`Copying ASAR to ${customRuntime}`);
+        const srcPath = path.join(getRootDirectory(), `dist/asar/${NAME}.asar`);
+        const destPath = path.join(getInstallDirectory(customRuntime), `OpenFin/resources/${NAME}.asar`);
+        fs.copyFileSync(srcPath, destPath);
+    }
+}
+
+/**
+ * Checks the given runtime version, to see if it is a named release channel.
+ *
+ * @param version Any valid runtime version or release channel
+ */
+export function isReleaseChannel(version: string): boolean {
+    return RELEASE_CHANNELS.indexOf(version.toLowerCase()) >= 0 || /stable-v\d+/.test(version);
+}
+
+/**
+ * Given a runtime version number (#.#.#.#) or channel name (stable, alpha, etc), will convert to a runtime version
+ * number.
+ *
+ * Note: If the input is a release channel and that runtime is not currently installed, this function also has the
+ * side-effect of installing that runtime on the machine. This means this function may take some time to complete.
+ *
+ * @param version Any valid runtime version or release channel
+ */
+export async function resolveRuntimeVersion(version: string): Promise<string> {
+    if (isReleaseChannel(version)) {
+        return installRuntime(version);
+    } else {
+        return version;
+    }
+}
+
+/**
+ * Given a valid runtime version number (NOT a release channel name), will return the version number that should be
+ * used for the "custom" runtime version that has the service ASAR swapped-out.
+ *
+ * The convention used is to replace the first number of the runtime version with the port number used by the local
+ * debug server. This results in a valid runtime number (#.#.#.# format), that is not going to clash with "vanilla"
+ * runtimes, other custom runtimes associated with another service.
+ *
+ * @param version Any valid runtime version number
+ */
+export function mapRuntimeVersion(version: string): string {
+    const {PORT} = getProjectConfig();
+    return version.replace(version.split('.')[0], PORT.toString());
+}
+
+/**
+ * Opens an adapter connection to the given runtime version. This will cause the RVM to download and install the
+ * runtime, if it is not already installed.
+ *
+ * Will return the version number of the given runtime, as reported by the connection. This will typically be the same
+ * string as the input argument, but will differ if `version` was the name of a release channel.
+ *
+ * @param version Any valid runtime version number or release channel
+ */
+export async function installRuntime(version: string): Promise<string> {
+    // Use the JS adapter to start an application on this runtime, then immediately exit
+    const connection = await connect({
+        uuid: 'temp-app',
+        runtime: {version}
+    });
+    const runtimeVersion = await connection.System.getVersion();
+    await connection['wire'].wire.shutdown();
+
+    return runtimeVersion;
+}
+
+/**
+ * Checks if the given runtime version is installed, by looking for a corresponding folder within the runtime
+ * installation directory.
+ *
+ * @param version Any valid runtime version number
+ */
+export function isRuntimeInstalled(version: string): boolean {
+    let runtimeDirectory;
+
+    try {
+        runtimeDirectory = getInstallDirectory(version);
+    } catch (e) {
+        // Avoid a hard failure in these cases by just assuming runtime isn't installed, no harm in
+        // calling `installRuntime` for an installed runtime.
+        console.warn(`Error when determining if runtime ${version} is installed (${e?.message}) - will continue as if it is not installed`);
+        return false;
+    }
+
+    return fs.existsSync(runtimeDirectory);
+}
+
+/**
+ * Gets the DEFAULT install directory for the given OpenFin runtime version. This is the location where that runtime
+ * version would be expected to exist - the specific runtime version may or may not be installed.
+ *
+ * Whilst the OpenFin install location can be overidden via DOS/registry, it is assumed that these tools will only be
+ * ran on desktops that use the default install location.
+ *
+ * @param version Any valid runtime version number
+ */
+function getInstallDirectory(version: string): string {
+    let dir;
+
+    // TODO: Check mac/linux paths
+    switch (os.platform()) {
+        case 'cygwin':
+        case 'win32':
+            dir = process.env.LOCALAPPDATA;
+            break;
+        case 'darwin':
+            dir = '~/Library/Application Support';
+            break;
+        default: // Linux
+            dir = process.env.XDG_CONFIG_HOME || '~/.config';
+            break;
+    }
+
+    if (!dir) {
+        throw new Error('Install directory not known');
+    }
+
+    return path.join(dir, 'OpenFin/runtime', version);
+}

--- a/src/webpack/webpackTools.ts
+++ b/src/webpack/webpackTools.ts
@@ -6,7 +6,7 @@ import * as ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import {getRootDirectory} from '../utils/getRootDirectory';
 import {getProjectConfig} from '../utils/getProjectConfig';
 import {getProjectPackageJson} from '../utils/getProjectPackageJson';
-import {getProviderPath} from '../utils/getProviderUrl';
+import {getProviderPath} from '../utils/manifest';
 
 /**
  * Custom options which can be passed into webpack.

--- a/src/webpack/webpackTools.ts
+++ b/src/webpack/webpackTools.ts
@@ -3,9 +3,10 @@ import * as MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import * as webpack from 'webpack';
 import * as ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 
+import {getRootDirectory} from '../utils/getRootDirectory';
 import {getProjectConfig} from '../utils/getProjectConfig';
 import {getProjectPackageJson} from '../utils/getProjectPackageJson';
-import {getRootDirectory} from '../utils/getRootDirectory';
+import {getProviderPath} from '../utils/getProviderUrl';
 
 /**
  * Custom options which can be passed into webpack.
@@ -149,10 +150,10 @@ export function createConfig(outPath: string, entryPoint: string | webpack.Entry
  * Will be removed once the RVM supports relative paths within app.json files
  */
 export const manifestPlugin = (() => {
-    const {NAME, PORT, IS_SERVICE} = getProjectConfig();
+    const {NAME, PORT} = getProjectConfig();
 
     return new CopyWebpackPlugin([{
-        from: IS_SERVICE ? './res/provider/app.json' : './res/app.json',
+        from: getProviderPath(),
         to: '.',
         transform: (content) => {
             const config = JSON.parse(content.toString());


### PR DESCRIPTION
**Overview**
Added `-a`/`--asar` CLI arg to 'start' and 'test int' commands, to start the service provider via runtime injection. The service must declare that it supports this behaviour (via a new `RUNTIME_INJECTABLE` config parameter) in order for the `--asar` flag to be usable.

The `--asar` flag is usable on both the `start` and `test int` commands. It defaults to `false` when running the demo app (as debugging is much easier when running through the standard "service" architecture), and `true` in integration tests (as this is how we expect apps to use FDC3, and so how we should run it when we test). Integration tests can also be ran in non-asar mode (use `--asar false`) in case the runtime injection is suspected as the cause of a test failure.

**Implementation**
At a high level, runtime injection works by performing two main tasks:
- Updated the manifest middleware to convert service declarations to 'runtime injection' arguments
- Util functions to create custom runtime versions

_Middleware_
The middleware that serves-up manifest files has some extra logic to process the `"services"` section of a manifest and replace any reference to the current service with an `{NAME}Api` flag (e.g. `"fdc3Api": true`) in the app's `startup_app` section.

Note: This manifest rewriting doesn't currently support platforms-based apps.

_Custom runtimes_
A util function that can prepare custom runtime versions. This will build the app as an ASAR, then clone the installation folder of the current runtime, and swap-out the runtime ASAR for the locally-built version. This is also integrated into the above middleware, to ensure that the tooling won't generate a manifest with a non-existant runtime version.

The runtime creation includes checks to ensure that this works even on clean installs. If the target runtime isn't currently installed, it will first be downloaded. The use of runtime release channels, rather than a specific runtime version number (eg: `npm start -- -runtime canary --asar`) is also supported.

The "fake" runtime is created by converting the first number of the runtime version to the port on which the local server runs. For example - running FDC3 via ASAR on `15.80.48.13`, results in the creation of the `3923.80.48.13` folder, whose contents are identical to the `15.80.48.13` runtime, except for the `fdc3.asar` file. This naming convention allows any other apps to work as normal (as the original runtime is unmodified), and allows for different services using runtime injection on the same runtime version - assuming that different services continue to use different port numbers.

**Changelist**
- Added `-a`/`--asar` CLI arg to 'start' and 'test int' commands.
- Can construct a custom runtime version that includes a locally-built service ASAR.
- Adds runtime-related utils, install a runtime, resolve channel alias, etc.
- Tooling now contains utils to convert a service declaration to a runtime-injected manifest.
- Will now build hooks with ES5 target.
- The static/demo/write args are now properly boolean, can be disabled via CLI when enabled-by-default through a hook.
- Cleaned up write/writeToDisk mismatches, and switched 'noDemo' to 'demo'.