### PR TITLE
[SERVICE-989] Fixed runtime release channel bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -610,9 +610,9 @@
       }
     },
     "@types/copy-webpack-plugin": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@types/copy-webpack-plugin/-/copy-webpack-plugin-4.4.4.tgz",
-      "integrity": "sha512-D8NyCMfHFWi638Cn5gi88mELGrISQdzDAcmOk4j70bzm0kLey99Zp5xsFsL44qPi+a22tcB39U5jiJiV2XMd9A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/copy-webpack-plugin/-/copy-webpack-plugin-5.0.0.tgz",
+      "integrity": "sha512-yQHocgdgES7W5Q2UyxJ5cj/E6MrV1zq3MZ8jdApS9NJKqax+rux9IE3QAbBmNCGbgivEsejrkIq3Rm76JLubkg==",
       "dev": true,
       "requires": {
         "@types/minimatch": "*",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@types/archiver": "^2.1.3",
-    "@types/copy-webpack-plugin": "^4.4.4",
+    "@types/copy-webpack-plugin": "^5.0.0",
     "@types/express": "^4.17.0",
     "@types/mini-css-extract-plugin": "^0.8.0",
     "@types/mkdirp": "^0.5.2",

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -21,7 +21,7 @@ export function createAppJsonMiddleware(args: Pick<CLIArguments, 'providerVersio
         // Parse app.json
         let config: ClassicManifest;
         try {
-            config = getManifest(configPath, RewriteContext.DEBUG, args);
+            config = await getManifest(configPath, RewriteContext.DEBUG, args);
         } catch (e) {
             next();
             return;

--- a/src/webpack/webpackTools.ts
+++ b/src/webpack/webpackTools.ts
@@ -156,9 +156,9 @@ export const manifestPlugin = (() => {
     return new CopyWebpackPlugin([{
         from: getProviderPath(),
         to: '.',
-        transform: (content, path) => {
+        transform: async (content, path) => {
             // Run the manifest through 'getManifest', to replace any ${} params
-            const config = getManifest(path, RewriteContext.DEPLOY, {providerVersion: VERSION || 'default'});
+            const config = await getManifest(path, RewriteContext.DEPLOY, {providerVersion: VERSION || 'default'});
             return JSON.stringify(config, null, 4);
         }
     }]);


### PR DESCRIPTION
Fixed bug where using a runtime release channel could result in invalid version number in manifests.

Also allows cross-runtime testing when using asars, and adds caching of runtime channel look-ups as this involves spinning-up an application, which can take some time.