### PR TITLE
[SERVICE-989] Fixed 'prepareRuntime' ordering in test runner

### DIFF
--- a/src/utils/getManifest.ts
+++ b/src/utils/getManifest.ts
@@ -6,7 +6,7 @@ import {getProjectConfig} from './getProjectConfig';
 import {getJsonFileSync} from './getJsonFile';
 import {getProviderPath, getProviderUrl} from './manifest';
 import {ClassicManifest, PlatformManifest, ServiceDeclaration} from './manifests';
-import {resolveRuntimeVersion} from './runtime';
+import {isRuntimeInstalled, mapRuntimeVersion, resolveRuntimeVersion} from './runtime';
 import {replaceUrlParams} from './url';
 
 let providerRuntime: string;
@@ -78,7 +78,12 @@ export async function getManifest(
         // Need to tweak the version if there's a "--runtime" override, or this is the same runtime as the provider
         if (runtime || runtimeVersion === getProviderRuntime()) {
             // Will need to run on a custom runtime version for ASAR to contain the latest provider code
-            runtimeVersion = runtimeVersion.replace(runtimeVersion.split('.')[0], PORT.toString());
+            runtimeVersion = mapRuntimeVersion(runtimeVersion);
+
+            // Warn if runtime isn't installed
+            if (!isRuntimeInstalled(runtime)) {
+                console.warn(`Creating a manifest that uses runtime ${runtime}, but that runtime is not currently installed`);
+            }
         }
     }
 

--- a/src/utils/timeout.ts
+++ b/src/utils/timeout.ts
@@ -1,0 +1,25 @@
+/**
+ * Wraps the given promise in a timeout. If the timeout is exceeded, a second action will be triggered.
+ *
+ * Method returns the result of `action` if it completes within the timeout, or the result of `timeoutAction` if the
+ * timeout is exceeded.
+ *
+ * The original action is passed to the timeout handler, so that the overall function can still return the original
+ * result if desired.
+ *
+ * @param action Promise that should be wrapped in a timeout
+ * @param timeoutMs How long 'action' is given to resolve
+ * @param timeoutAction Callback that is ran if the timeout is exceeded
+ */
+export async function withTimeout<T>(action: Promise<T>, timeoutMs: number, timeoutAction: (action: Promise<T>) => Promise<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+            timeoutAction(action).then(resolve, reject);
+        }, timeoutMs);
+
+        action.then((result) => {
+            clearTimeout(timeout);
+            resolve(result);
+        }, reject);
+    });
+}


### PR DESCRIPTION
Ensure custom runtimes are set up before attempting to launch main test-app.

Also added additional logging around runtime installs, and guards for attempting to install a non-existant runtime or for the test app not starting.