### PR TITLE
[N/A] Manifest util bugfix

### DIFF
--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -28,7 +28,7 @@ export function createAppJsonMiddleware(args: Pick<CLIArguments, 'providerVersio
         }
 
         // If this is the provider manifest, ensure window is always visible
-        if (configPath.indexOf('/provider/') && config.startup_app?.autoShow === false) {
+        if (isProvider && config.startup_app?.autoShow === false) {
             config.startup_app.autoShow = true;
         }
 

--- a/src/utils/getManifest.ts
+++ b/src/utils/getManifest.ts
@@ -52,7 +52,7 @@ type StartupAppWithInjection = ClassicManifest['startup_app'] & {[key: string]: 
 export async function getManifest(
     configPath: string,
     context: RewriteContext,
-    args: Pick<Partial<CLIArguments>, 'providerVersion' | 'asar' | 'runtime'>
+    args: Pick<Partial<CLIArguments>, 'providerVersion' | 'asar' | 'runtime'> = {}
 ): Promise<ClassicManifest> {
     const {providerVersion, asar, runtime} = {providerVersion: 'default', asar: false, runtime: '', ...args};
     const {PORT, NAME, CDN_LOCATION, IS_SERVICE, RUNTIME_INJECTABLE} = getProjectConfig();

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -46,9 +46,11 @@ export function getProviderUrl(version: string, manifestUrl?: string): string {
         } else if (version === 'stable') {
             // Use the latest stable version
             url = `${CDN_LOCATION}/app.json`;
+            overrideArgs.VERSION = '';
         } else if (version === 'staging') {
             // Use the latest staging build
             url = `${CDN_LOCATION}/app.staging.json`;
+            overrideArgs.VERSION = '';
         } else if (version === 'testing') {
             // Use the optional testing provider if exists.
             const testingProviderResponse = existsSync(join(getRootDirectory(), 'res/test/provider.json'));
@@ -68,6 +70,9 @@ export function getProviderUrl(version: string, manifestUrl?: string): string {
         } else {
             throw new Error(`Not a valid version number or channel: ${version}`);
         }
+
+        // Apply template params
+        url = replaceUrlParams(url, overrideArgs);
 
         // Cache URL, to avoid duplicate filesystem reads/regexes/etc
         urlCache[version] = replaceUrlParams(url);

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,5 +1,6 @@
 import {getProjectConfig, Config} from './getProjectConfig';
 
+const doubleSlashes: RegExp = /\/\//g;
 const trailingSlash: RegExp = /\/$/;
 const trimFragment: RegExp = /^\/*(.*?)\/*$/;
 
@@ -27,7 +28,7 @@ export function join(...fragments: string[]): string {
  * @param urlTemplate A valid URL, or string template that resolves to a valid URL
  * @param overrideArgs Optional config overrides, to apply before evaluating template
  */
-export function replaceUrlParams(urlTemplate: string, overrideArgs?: Partial<Config>) {
+export function replaceUrlParams(urlTemplate: string, overrideArgs?: Partial<Config>): string {
     if (urlTemplate.indexOf('${') === -1) {
         // Not a template, just a "plain" URL
         return urlTemplate;
@@ -48,6 +49,15 @@ export function replaceUrlParams(urlTemplate: string, overrideArgs?: Partial<Con
             templateCache[urlTemplate] = templateFunc;
         }
 
-        return templateFunc(...Object.values(params)).replace(trailingSlash, '');
+        // Apply template
+        const result = templateFunc(...Object.values(params));
+
+        // Sanitize resulting URL
+        const url = new URL(result);
+        url.pathname = url.pathname
+            .replace(trailingSlash, '')
+            .replace(doubleSlashes, '/');
+
+        return url.toString();
     }
 }


### PR DESCRIPTION
Fixed a bug that was causing the `--providerVersion` argument to produce incorrect URLs when used alongside a templated `CDN_LOCATION` parameter, as happens within service projects (eg: https://cdn.openfin.co/services/openfin/${VERSION}). Fixed bug in `autoShow` check that meant provider window wouldn't always show.

Also slight tweak to getManifest util - made 'args' optional, given that all of its properties are also optional. Makes this a little easier to use outside of the tooling, for example in `hooks.ts` within a project.