### PR TITLE
[N/A] Correctly parse 'null' and 'undefined' when used as environment vars

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,6 +7,7 @@ import {CLIArguments} from '../types';
 import {getProjectConfig} from '../utils/getProjectConfig';
 import {getProviderUrl, getManifest} from '../utils/manifest';
 import {getRootDirectory} from '../utils/getRootDirectory';
+import {join, replaceUrlParams} from '../utils/url';
 import {executeWebpack} from '../webpack/executeWebpack';
 
 import {createAppJsonMiddleware, createCustomManifestMiddleware} from './middleware';
@@ -101,16 +102,17 @@ export async function startApplication(args: CLIArguments) {
 
 function getStartupManifest(): string {
     const {PORT, MANIFEST, IS_SERVICE} = getProjectConfig();
+    const manifest = MANIFEST && replaceUrlParams(MANIFEST);
 
-    if (!MANIFEST) {
+    if (!manifest) {
         // No project-specific manifestUrl
         return IS_SERVICE ? `http://localhost:${PORT}/demo/app.json` : `http://localhost:${PORT}/app.json`;
-    } else if (MANIFEST.includes('://')) {
+    } else if (manifest.includes('://')) {
         // Fully-qualified manifestUrl
-        return MANIFEST;
+        return manifest;
     } else {
         // Prepend base URL to custom manifest path
-        return `http://localhost:${PORT}${MANIFEST.startsWith('/') ? '' : '/'}${MANIFEST}`;
+        return join(`http://localhost:${PORT}`, manifest);
     }
 }
 

--- a/src/utils/getProjectConfig.ts
+++ b/src/utils/getProjectConfig.ts
@@ -159,6 +159,14 @@ export function getProjectConfig<T extends Config = Config>(): Readonly<T> {
 }
 
 function parseCLIArg<T>(input: string, defaultValue: T): T {
+    // Handle specific special-case values
+    if (input === 'null') {
+        return null!;
+    } else if (input === 'undefined') {
+        return undefined!;
+    }
+
+    // Parse input according to the type of the default arg
     switch (typeof defaultValue) {
         case 'string':
             return input as unknown as T;


### PR DESCRIPTION
When config parameters (as defined in `project.config.json`/`services.config.json`) are set through the use of environment variables, they will come through as strings and will be parsed according to their expected type.

This change will explicitly check for null and undefined values. These values can be used with any config argument, regardless of its expected type (string/number/etc).

Also includes a small, unrelated, change - to allow URL params within the `MANIFEST` config argument. Allows, for example, the use of `"MANIFEST": "http://localhost:${PORT}/path/to/app.json"`.